### PR TITLE
Change Dockerfile to multi stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
-FROM golang:1.19
-WORKDIR /bin/main/
-COPY main.go .
-RUN go build main.go
-EXPOSE 8080
-CMD [ "./main" ]
+FROM golang:alpine AS build
+LABEL stage=gobuilder
+ENV CGO_ENABLED 0
+ENV GOOS linux
+WORKDIR /build
+COPY . .
+RUN go build -o /build/main main.go
+FROM alpine
+WORKDIR /build
+COPY --from=build /build/main /build/main
+CMD ["./main"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Go-REST-service
-This is a simple rest service written in go, not super useful, just something 
+This is a simple rest service written in go, not super useful, just something
 for me to play go.
 
 ## How to run and test rest service
@@ -8,6 +8,6 @@ for me to play go.
 3) open  `localhost:8080/hello` in webbrowser
 
 ## How to create a docker image, run and test it
-1) run `docker build -t goRestService .` in terminal
+1) run `docker build -t gorestservice .` in terminal
 2) run `docker run --name gorestservice -d -p 8080:8080 gorestservice` in terminal
-3) open  `localhost:8080/hello` in webbrowser
+3) open `localhost:8080/hello` in webbrowser


### PR DESCRIPTION
This PR will change the Dockerfile so that there will be two stages: one for building the executable and one for running the executable.
This will reduce the docker image size (since the base image for the final image can be alpine instead of Golang.
Size reduced from 850 MB to 11.5 MB.
<img width="649" alt="image_compare" src="https://user-images.githubusercontent.com/4264462/200075613-f89d400d-4ea2-49b1-9241-13236396185b.png">
